### PR TITLE
feat: allow configuring git repo branch name and create URL

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,9 +1,21 @@
 const config = {
+	gitCreateUrl: {
+		title: 'Git Create URL',
+		description: 'Custom URL to create git repo.',
+		type: 'string',
+		default: 'https://github.com/new',
+	},
 	gitUrl: {
 		title: 'Git URL',
 		description: 'URL of git repo.',
 		type: 'string',
 		default: '',
+	},
+	gitBranch: {
+		title: 'Git Branch',
+		description: 'Branch to store settings in.',
+		type: 'string',
+		default: 'main',
 	},
 	commitMessage: {
 		title: 'Commit Message',

--- a/lib/git.js
+++ b/lib/git.js
@@ -54,6 +54,55 @@ async function invalidGitUrl (invalidUrl, message = '', description = '') {
 	return promise
 }
 
+async function invalidGitBranch (invalidUrl) {
+	let resolveFn
+	let rejectFn
+	const promise = new Promise((resolve, reject) => {
+		resolveFn = resolve
+		rejectFn = reject
+	})
+	let rejectOnDismiss = true
+
+	const notification = atom.notifications.addError((invalidUrl ? 'Invalid Git Branch' : 'No Git Branch'), {
+		description: (invalidUrl
+			? `Invalid Branch: \`${invalidUrl}\``
+			: 'No Git branch found in settings'),
+		dismissable: true,
+		buttons: [{
+			text: 'Enter Git Branch',
+			async onDidClick () {
+				rejectOnDismiss = false
+				notification.dismiss()
+				const inputView = new InputView({
+					title: 'Enter Git Branch',
+					description: 'Branch should already exist.',
+					placeholder: 'Git Branch',
+					value: invalidUrl,
+				})
+				const gitUrl = await inputView.getInput()
+				if (gitUrl) {
+					atom.config.set('sync-settings-git-location.gitBranch', gitUrl)
+					resolveFn(gitUrl)
+				}
+				rejectFn()
+			},
+		}, {
+			text: 'Package settings',
+			onDidClick () {
+				notification.dismiss()
+				atom.workspace.open('atom://config/packages/sync-settings-git-location')
+			},
+		}],
+	})
+	notification.onDidDismiss(() => {
+		if (rejectOnDismiss) {
+			rejectFn()
+		}
+	})
+
+	return promise
+}
+
 async function getGitUrl (allowEmpty) {
 	let gitUrl = atom.config.get('sync-settings-git-location.gitUrl')
 	if (gitUrl) {
@@ -70,9 +119,45 @@ async function getGitUrl (allowEmpty) {
 	}
 }
 
-async function displayError (error, action, retryFn, gitUrl) {
+async function getGitCreateUrl () {
+	let gitCreateUrl = atom.config.get('sync-settings-git-location.gitCreateUrl')
+	if (gitCreateUrl) {
+		return gitCreateUrl.trim()
+	}
+    return 'https://github.com/new'
+}
+
+async function getGitBranch () {
+	let gitBranch = atom.config.get('sync-settings-git-location.gitBranch')
+	if (gitBranch) {
+        try {
+            await git(`check-ref-format refs/heads/${gitBranch}`)
+            return gitBranch.trim()
+        } catch (ex) {
+            atom.notifications.addWarning(`Sync-Settings: Defaulting to "main" branch`, {
+    			dismissable: true,
+    			detail: 'You have invalid branch name set in settings, sync-settings is defaulting to "main" branch.',
+    		})
+        }
+	}
+    else
+    {
+        atom.notifications.addWarning(`Sync-Settings: Defaulting to "main" branch`, {
+			dismissable: true,
+			detail: 'You have invalid branch name set in settings, sync-settings is defaulting to "main" branch.',
+		})
+    }
+    return 'main'
+}
+
+async function displayError (error, action, retryFn, gitUrl, gitBranch) {
 	try {
 		console.error(`Error ${action}:`, error)
+
+		if (['remote branch', 'could not find remote branch'].some(e => error.message.toLowerCase().includes(e))) {
+			await invalidGitBranch(gitBranch)
+			return await retryFn()
+		}
 
 		if (['not found', 'does not exist'].some(e => error.message.toLowerCase().includes(e))) {
 			await invalidGitUrl(gitUrl)
@@ -96,14 +181,14 @@ async function displayError (error, action, retryFn, gitUrl) {
 	}
 }
 
-async function cloneToLocalRepo (gitUrl) {
+async function cloneToLocalRepo (gitUrl, gitBranch) {
 	const repoPath = await fs.mkdtemp(path.join(os.tmpdir(), 'sync-settings-git-clone-'))
 	const env = {
 		...process.env,
 		GIT_TERMINAL_PROMPT: '0',
 	}
 	try {
-		await git(`clone --depth 1 ${gitUrl} .`, repoPath, '', { env })
+		await git(`clone --branch ${gitBranch} --depth 1 ${gitUrl} .`, repoPath, '', { env })
 	} catch (ex) {
 		if (ex.message && ex.message.includes('fatal: Cannot prompt because terminal prompts have been disabled.')) {
 			throw new Error(`Cannot connect to the repo. Try running \`git clone --depth 1 ${gitUrl}\` in a terminal and follow the prompts to authenticate.`)
@@ -174,7 +259,17 @@ module.exports = {
 	 */
 	async create () {
 		// TODO: use octokit?
-		shell.openExternal('https://github.com/new')
+        let gitCreateUrl
+        try {
+            gitCreateUrl = await getGitCreateUrl()
+		    shell.openExternal(gitCreateUrl)
+        }
+        catch (err) {
+			if (err) {
+				return displayError(err, 'creating backup', () => this.get(), gitUrl)
+			}
+		}
+
 	},
 
 	/**
@@ -185,7 +280,8 @@ module.exports = {
 		let gitUrl, repoPath
 		try {
 			gitUrl = await getGitUrl()
-			const repoPath = await cloneToLocalRepo(gitUrl)
+            gitBranch = await getGitBranch()
+			const repoPath = await cloneToLocalRepo(gitUrl, gitBranch)
 
 			const files = await readAllFiles(repoPath)
 			const time = await getLogTime(repoPath)
@@ -193,7 +289,7 @@ module.exports = {
 			return { files, time }
 		} catch (err) {
 			if (err) {
-				return displayError(err, 'getting backup', () => this.get(), gitUrl)
+				return displayError(err, 'getting backup', () => this.get(), gitUrl, gitBranch)
 			}
 		} finally {
 			if (repoPath) {
@@ -220,7 +316,8 @@ module.exports = {
 		let gitUrl, repoPath
 		try {
 			gitUrl = await getGitUrl()
-			const repoPath = await cloneToLocalRepo(gitUrl)
+            gitBranch = await getGitBranch()
+			const repoPath = await cloneToLocalRepo(gitUrl,gitBranch)
 
 			for (const file in files) {
 				const fileName = file.replace(/\\/g, '/')
@@ -267,7 +364,7 @@ module.exports = {
 			return { time }
 		} catch (err) {
 			if (err) {
-				return displayError(err, 'updating backup', () => this.update(files), gitUrl)
+				return displayError(err, 'updating backup', () => this.update(files), gitUrl, gitBranch)
 			}
 		} finally {
 			if (repoPath) {


### PR DESCRIPTION
Hi,

I needed to store configs on branches of single git repo, so I made small adjustments to your package.

Ability to specify create URL is a kind-of afterthought but I came to conclusion that it may be useful somehow.